### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,4 +1,6 @@
 name: Go
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/benpate/data-mock/security/code-scanning/1](https://github.com/benpate/data-mock/security/code-scanning/1)

To fix this issue, we should add a `permissions` key specifying the minimal permissions required for the workflow to operate. The best practice is to set this at the root level of the workflow file, so all jobs inherit it (unless a job needs an override). For the `go` workflow:  
- The steps only clone code, set up Go, run tests, upload coverage (using Codecov token, not GITHUB_TOKEN), and lint code.
- There is no indication that any step requires write access to the repository or pull requests.
- Therefore, setting `permissions: contents: read` at the root level suffices and follows least-privilege recommendations.
This should be added after the `name:` field and before `on:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
